### PR TITLE
Small WIN32 fixes to compile with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,26 +225,14 @@ else ()
 endif ()
 
 ###########################################################
-### edbr static libraro of shared source
-set(name edbr-lib)
-set(dir src)
-set(${name}_SRCS
-    ${dir}/messages.c
-    ${dir}/url.c
-    ${dir}/stringfile.c
-    ${dir}/html-tidy.c
-    ${dir}/decorate.c
-    ${dir}/http.c
-    ${dir}/auth.c
-    ${GEN_SOURCES}
-    )
-if (MSVC)
-    list(APPEND ${name}_SRCS win32/vsprtf.c win32/dirent.c)
-    list(APPEND ${name}_HDRS win32/vsprtf.h win32/dirent.h)
-    include_directories( win32 )
-endif ()
-add_library( ${name} ${${name}_SRCS} )
-set(add_LIBS ${name} ${add_LIBS})
+### edbr static library of shared source - not currently used.
+#  set(name edbr-lib)
+#  set(dir src)
+#  set(${name}_SRCS
+#      ${dir}/foo.c
+#      )
+#  add_library( ${name} ${${name}_SRCS} )
+#  set(add_LIBS ${name} ${add_LIBS})
 
 #######################################################
 ### main edbrowse app
@@ -273,6 +261,13 @@ set(${name}_SRCS
     ${dir}/buffers.c
     ${dir}/sendmail.c
     ${dir}/fetchmail.c
+    ${dir}/messages.c
+    ${dir}/url.c
+    ${dir}/stringfile.c
+    ${dir}/html-tidy.c
+    ${dir}/decorate.c
+    ${dir}/http.c
+    ${dir}/auth.c
 	${dir}/html.c
     ${dir}/format.c
     ${dir}/cookies.c
@@ -280,6 +275,7 @@ set(${name}_SRCS
     ${dir}/plugin.c
     ${dir}/jseng-moz.cpp
     ${ODBC_SRCS}
+    ${GEN_SOURCES}
     )
 set(${name}_HDRS
     ${dir}/eb.h
@@ -287,6 +283,11 @@ set(${name}_HDRS
     ${dir}/messages.h
     ${dir}/ebjs.h
     )
+if (MSVC)
+    list(APPEND ${name}_SRCS win32/vsprtf.c win32/dirent.c)
+    list(APPEND ${name}_HDRS win32/vsprtf.h win32/dirent.h)
+    include_directories( win32 )
+endif ()
 add_executable( ${name} ${${name}_SRCS} ${${name}_HDRS} )
 if (add_LIBS OR extra_LIBS)
     target_link_libraries( ${name} ${add_LIBS} ${extra_LIBS} )

--- a/src/jseng-moz.cpp
+++ b/src/jseng-moz.cpp
@@ -32,6 +32,9 @@ Exit codes are as follows:
 #include <limits>
 #include <iostream>
 #include <string>
+#ifdef DOSLIKE
+#include "vsprtf.h"
+#endif // DOSLIKE
 
 /* work around a bug where the standard UINT32_MAX isn't defined, I really hope this is correct */
 #ifndef UINT32_MAX

--- a/src/main.c
+++ b/src/main.c
@@ -1060,6 +1060,25 @@ void unreadConfigFile(void)
 	deleteNovsHosts();
 }				/* unreadConfigFile */
 
+/* Order is important here: mail{}, mime{}, table{}, then global keywords */
+#define MAILWORDS 0
+#define MIMEWORDS 8
+#define TABLEWORDS 15
+#define GLOBALWORDS 19
+
+static const char *const keywords[] = {
+		"inserver", "outserver", "login", "password", "from", "reply",
+		"inport", "outport",
+		"type", "desc", "suffix", "protocol", "program",
+		"content", "outtype",
+		"tname", "tshort", "cols", "keycol",
+		"adbook", "downdir", "maildir", "agent",
+		"jar", "nojs", "xyz@xyz",
+		"webtimer", "mailtimer", "certfile", "datasource", "proxy",
+		"linelength", "localizeweb", "jspool", "novs",
+		0
+	};
+
 /* Read the config file and populate the corresponding data structures. */
 /* This routine succeeds, or aborts via i_printfExit */
 void readConfigFile(void)
@@ -1082,24 +1101,6 @@ void readConfigFile(void)
 	struct DBTABLE *td;
 
 	unreadConfigFile();
-
-/* Order is important here: mail{}, mime{}, table{}, then global keywords */
-#define MAILWORDS 0
-#define MIMEWORDS 8
-#define TABLEWORDS 15
-#define GLOBALWORDS 19
-	static const char *const keywords[] = {
-		"inserver", "outserver", "login", "password", "from", "reply",
-		"inport", "outport",
-		"type", "desc", "suffix", "protocol", "program",
-		"content", "outtype",
-		"tname", "tshort", "cols", "keycol",
-		"adbook", "downdir", "maildir", "agent",
-		"jar", "nojs", "xyz@xyz",
-		"webtimer", "mailtimer", "certfile", "datasource", "proxy",
-		"linelength", "localizeweb", "jspool", "novs",
-		0
-	};
 
 	if (!fileTypeByName(configFile, false))
 		return;		/* config file not present */

--- a/win32/vsprtf.h
+++ b/win32/vsprtf.h
@@ -8,10 +8,15 @@
 
 #ifndef _VSPRTF_HXX_
 #define _VSPRTF_HXX_
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern int vasprintf (char **str, const char *fmt, va_list args);
 extern int asprintf (char **str, const char *fmt, ...);
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif // #ifndef _VSPRTF_HXX_
 // eof - vsprtf.hxx


### PR DESCRIPTION
But be aware the EXE does not appear to be running correctly... I do not think it is the result of my changes for WIN32, but maybe...

My first test run produced the following???

```
F:\Projects\edbrowse-geoff\build\Release>edbrowse.exe  ..\..\src\jsrt
no ssl certificate file specified; secure connections cannot be verified
21629
b
failed 85
failed 108
This page is finished, please use your back key or quit.
612
rr
javascript disabled
q
no file
q
```

So need help. Anything else I can do?
