### PR TITLE
README: add live link to userguide.html

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,8 @@ Use this program at your own risk.
 Netscape and Explorer are graphical browsers.
 Lynx and Links are screen browsers.
 This is a command line browser, the only one of its kind.
-The user's guide can be found in doc/usersguide.html (in this package).
+The user's guide can be found in doc/usersguide.html (in this package),
+online at https://rawgit.com/CMB/edbrowse/master/doc/usersguide.html.
 Of course this reasoning is a bit circular.
 You need to use a browser to read the documentation,
 which describes how to use the browser.


### PR DESCRIPTION
This may help visitors to the repository that use a graphical browser.

rawgit serves the copy from current master.  They request not using it "in production" but I suppose this repo is sufficiently low-traffic.
Another easy way to expose the html would be to enable Github Pages for this repo (this used to require a `gh-pages` branch but nowdays can be told to use `master`)