### PR TITLE
Authentication enhancements

### DIFF
--- a/doc/usersguide.html
+++ b/doc/usersguide.html
@@ -574,6 +574,7 @@ g : go to the link on the current line
 <br>i$* : push the last button on the current line
 <br>i* : switch to the buffer containing this textarea
 <br>i3? : describe the third input field on the current line
+<br>ipass2 : prompt for the content of the second input field, disabling echo
 <br>M4 : move this web page to session 4 and back up to the previous page
 <br>M : move this web page to an empty session and back up
 <br>js : allow javascript (toggle)
@@ -2190,6 +2191,13 @@ If the number you entered is not a perfect match for one of the options, it is t
 If it is not a valid menu number (e.g. out of range),
 edbrowse performs a partial match on the options, looking for those digits as a substring.
 This may seem confusing, but it is usually what you want.
+
+<P>
+If you would like your password to not be displayed on screen when you type it,
+you can use ipass (or ipass2 if the password is the second field) to get a no-echo
+prompt for your password.
+When printing anything you entered with ipass, or if the input field type is password,
+you will get wildcards back.
 
 <P>
 You can use i&lt;7 to pull the contents of session 7 into the current input field.

--- a/doc/usersguide_fr.html
+++ b/doc/usersguide_fr.html
@@ -534,6 +534,7 @@ g : suit le lien sur la ligne courante
 <br>i2* : appuie sur le 2ème bouton de la ligne courante, habituellement envoyer ou remettre à zéro
 <br>i$* : appuie sur le dernier bouton de la ligne courante
 <br>i3 ? : affiche la description du troisième formulaire de la ligne courante
+<br>ipass2 : invite a rentrer le texte du deuxième formulaire sans afficher d'écho
 <br>M4 : déplace cette page web en session 4 et revient à la page précédente
 <br>js : activation javascript (bascule)
 <br>xhr :  permet le XHR (bascule)
@@ -2269,6 +2270,15 @@ Si ce n'est pas un numéro valide du menu (par exemple hors de la gamme),
 je fais une comparaison partielle avec les options, recherchant ces chiffres 
 comme sous-chaîne.&nbsp;
 Ceci peut sembler confus, mais c'est habituellement ce que vous voulez obtenir.&nbsp;
+</p>
+
+<p>
+Si vous ne souhaitez pas voir votre mot de passe affiché lors de la saisie,
+vous pouvez utiliser «&nbsp;ipass&nbsp;» (ou par exemple «&nbsp;ipass2&nbsp;» s'il
+s'agit du deuxième champ) pour être invité à saisir le contenu du champ de manière
+cachée.
+Le texte renseigné avec ipass ou pour les formulaire de type mot de passe est
+restitué sous forme d'asterisques, et ne sera jamais affiché par la suite.
 </p>
 
 <p>

--- a/lang/msg-de
+++ b/lang/msg-de
@@ -215,7 +215,7 @@ kein vorheriger Text
 unerwarteter Text nach dem Kommando m
 0
 kein vorheriger Text, kann nicht sichern
-kann das g Kommando nicht auf einen Bereich anwenden
+kann das %s Kommando nicht auf einen Bereich anwenden
 g im Datenbankmodus nicht verfügbar
 kann das i%c Kommando nicht auf einen Bereich anwenden
 kann i< nicht in einem globalen Kommando verwenden
@@ -260,8 +260,8 @@ die Aktion der Eingabemaske ist keine URL
 JavaScript ist deaktiviert, kann EingabeMaske nicht verwenden
 Die Eingabemaske hat von HTTPS auf HTTP gewechselt und ist nun unsicher
 kann nicht über Protokoll %s versenden
-%d ist außerhalb des Bereichs; nutzen Sie %c1 bis %c%d
-%d ist außerhalb des Bereichs; nutzen Sie %c1, oder einfach %c
+%d ist außerhalb des Bereichs; nutzen Sie %s1 bis %s%d
+%d ist außerhalb des Bereichs; nutzen Sie %s1, oder einfach %s
 kann nicht mehrere Vorkommen einer leeren Zeichenkette ersetzen
 Download abgebrochen
 kein regulärer Ausdruck nach Kommando %C

--- a/lang/msg-en
+++ b/lang/msg-en
@@ -215,7 +215,7 @@ no previous text
 unexpected text after the M command
 moved to session %d\n
 no previous text, cannot back up
-cannot apply the g command to a range
+cannot apply the %s command to a range
 g not available in database mode
 cannot apply the i%c command to a range
 cannot use i< in a global command
@@ -260,8 +260,8 @@ the action of the form is not a url
 javascript is disabled, cannot activate this form
 This form has changed from https to http, and is now insecure
 cannot submit using protocol %s
-%d is out of range, please use %c1 through %c%d
-%d is out of range, please use %c1, or simply %c
+%d is out of range, please use %s1 through %s%d
+%d is out of range, please use %s1, or simply %s
 cannot replace multiple instances of the empty string
 download aborted.
 no regular expression after %c

--- a/lang/msg-fr
+++ b/lang/msg-fr
@@ -215,7 +215,7 @@ pas de texte antérieur
 texte inattendu après la commande M
 0
 pas de texte antérieur, sauvegarde impossible
-impossible d'appliquer la commande g à un intervalle
+impossible d'appliquer la commande %s à un intervalle
 g impossible en mode base de données
 impossible d'appliquer la commande i%c à un intervalle
 impossible d'utiliser i< dans une commande globale
@@ -260,8 +260,8 @@ l'action de ce formulaire ne renvoie pas à une destination URL
 javascript désactivé, impossible d'activer ce formulaire
 Le formulaire est passé du mode https au mode http, il n'est plus sécurisé
 impossible de soumettre avec le protocole %s
-%d hors limites, utilisez s'il vous plait %c1 à %c%d
-%d hors limites, utilisez s'il vous plait  %c1, ou simplement %c
+%d hors limites, utilisez s'il vous plait %s1 à %s%d
+%d hors limites, utilisez s'il vous plait  %s1, ou simplement %s
 impossible de remplacer plusieurs fois la chaîne vide
 téléchargement abandonné.
 pas d'expression régulière après %c

--- a/lang/msg-pl
+++ b/lang/msg-pl
@@ -215,7 +215,7 @@ brak poprzedniego tekstu
 nieoczekiwany tekst po poleceniu 'M'
 przeniesiono do sesji %d\n
 brak poprzedniego tekstu, nie można zapisać
-nie można zastosować polecenia 'g' do zakresu
+nie można zastosować polecenia '%s' do zakresu
 polecenie 'g' niedostępne w trybie bazy danych
 nie można zastosować polecenia 'i%c' do zakresu
 nie można użyć 'i<' w poleceniu globalnym
@@ -260,8 +260,8 @@ akcja tego formularza nie jest URLem
 JavaScript jest wyłączony, nie można aktywować formularza
 Ten formularz zmienił się z http na https i nie jest teraz bezpieczny
 nie można wysłać używając protokołu %s
-%d jest poza zakresem, używaj %c1 do %c%d
-%d jest poza zakresem, użyj %c1 lub po prostu %c
+%d jest poza zakresem, używaj %s1 do %s%d
+%d jest poza zakresem, użyj %s1 lub po prostu %s
 nie można zamienić wielu instancji pustego ciągu znaków
 anulowano pobieranie.
 brak wyrażenia regularnego po %c

--- a/lang/msg-pt_br
+++ b/lang/msg-pt_br
@@ -215,7 +215,7 @@ sem texto anterior
 texto inesperado após o comando M
 movido para a sessão %d\n
 sem texto anterior; impossível copiar
-impossível aplicar comando g a um intervalo
+impossível aplicar comando %s a um intervalo
 g não disponível em modo banco de dados
 impossível aplicar comando i%c a um intervalo
 impossível usar i< num comando global
@@ -260,8 +260,8 @@ ação do formulário não é uma URL
 javascript desligado; impossível ativar este formulário
 formulário mudou de https para http e agora não é seguro
 impossível submeter usando protocolo %s
-%d fora do intervalo; por favor use %c1 até %c%d
-%d fora do intervalo; por favor use %c1 ou simplesmente %c
+%d fora do intervalo; por favor use %s1 até %s%d
+%d fora do intervalo; por favor use %s1 ou simplesmente %s
 impossível substituir várias ocorrências de uma cadeia vazia
 transferência abortada.
 sem expressão regular após %c

--- a/lang/msg-ru
+++ b/lang/msg-ru
@@ -215,7 +215,7 @@ no previous text
 unexpected text after the M command
 0
 no previous text, cannot back up
-cannot apply the g command to a range
+cannot apply the %s command to a range
 g not available in database mode
 cannot apply the i%c command to a range
 cannot use i< in a global command
@@ -260,8 +260,8 @@ the action of the form is not a url
 javascript is disabled, cannot activate this form
 This form has changed from https to http, and is now insecure
 cannot submit using protocol %s
-%d is out of range, please use %c1 through %c%d
-%d is out of range, please use %c1, or simply %c
+%d is out of range, please use %s1 through %s%d
+%d is out of range, please use %s1, or simply %s
 cannot replace multiple instances of the empty string
 download aborted.
 no regular expression after %c

--- a/src/decorate.c
+++ b/src/decorate.c
@@ -361,6 +361,8 @@ void htmlInputHelper(struct htmlTag *t)
 		}
 	}
 	t->itype = n;
+	if (n == INP_PW)
+		t->masked = true;
 
 	s = attribVal(t, "maxlength");
 	len = 0;

--- a/src/eb.h
+++ b/src/eb.h
@@ -523,7 +523,8 @@ struct htmlTag {
 	bool onload:1;
 	bool onunload:1;
 	bool doorway:1; /* doorway to javascript */
-	bool visited: 1;
+	bool visited:1;
+	bool masked:1;
 	char subsup;		/* span turned into sup or sub */
 	uchar itype;		/* input type = */
 	int ninp;		/* number of nonhidden inputs */

--- a/src/ebprot.h
+++ b/src/ebprot.h
@@ -197,6 +197,8 @@ const char *findProxyForURL(const char *url) ;
 bool frameExpand(bool expand, int ln1, int ln2);
 struct htmlTag *line2frame(int ln);
 bool reexpandFrame(void);
+int prompt_and_read(int prompt, char *buffer, int buffer_length, int error_message, bool hide_echo);
+
 
 /* sourcefile=main.c */
 const char *mailRedirect(const char *to, const char *from, const char *reply, const char *subj) ;

--- a/src/ebprot.h
+++ b/src/ebprot.h
@@ -320,6 +320,7 @@ char *conciseTime(time_t t);
 bool lsattrChars(const char *buf, char *dest);
 char *lsattr(const char *path, const char *flags);
 void ttySaveSettings(void) ;
+void ttySetEcho(bool enable_echo);
 #ifndef _INC_CONIO
 int getche(void) ;
 int getch(void) ;

--- a/src/http.c
+++ b/src/http.c
@@ -1927,7 +1927,7 @@ static const char *message_for_response_code(int code)
  * in a function, and we call that function twice.
  * After the call, the buffer contains the user's input, without a newline.
  * The return value is the length of the string in buffer. */
-static int
+int
 prompt_and_read(int prompt, char *buffer, int buffer_length, int error_message,
 		bool hide_echo)
 {

--- a/src/messages.h
+++ b/src/messages.h
@@ -315,7 +315,7 @@ enum {
 	MSG_MAfter,
 	MSG_MovedSession,
 	MSG_NoBackup,
-	MSG_RangeG,
+	MSG_RangeCmd,
 	MSG_DBG,
 	MSG_RangeI,
 	MSG_IG,

--- a/src/stringfile.c
+++ b/src/stringfile.c
@@ -1178,7 +1178,29 @@ static void ttyRaw(int charcount, int timeout, bool isecho)
 		buf.c_lflag |= ECHO;
 	tcsetattr(0, TCSANOW, &buf);
 }				/* ttyRaw */
+#endif // #ifdef DOSLIKE y/n
 
+void ttySetEcho(bool enable_echo) {
+#ifndef DOSLIKE
+	struct termios termios;
+
+	if (!isInteractive)
+		return;
+
+	tcgetattr(0, &termios);
+	if (enable_echo) {
+		termios.c_lflag |= ECHO;
+		termios.c_lflag &= ~ECHONL;
+	} else {
+		termios.c_lflag &= ~ECHO;
+		termios.c_lflag |= ECHONL;
+	}
+	tcsetattr(0, TCSANOW, &termios);
+#endif // #ifndef DOSLIKE
+}
+
+
+#ifndef DOSLIKE
 /* simulate MSDOS getche() system call */
 int getche(void)
 {
@@ -1200,7 +1222,7 @@ int getch(void)
 	return c;
 }				/* getche */
 
-#endif // #ifdef DOSLIKE y/n
+#endif // #ifndef DOSLIKE
 
 char getLetter(const char *s)
 {


### PR DESCRIPTION
Hi,

not quite sure how to contribute as there does not seem to be patches on the mailing list.
I'm starting simple with two small patches:
 - first one just disables local echo for http basic auth password prompt, as I don't like to leave this stuff in my scrollback buffer
 - second one adds an option to enable curl SPNEGO (--negotiate) authentication.
There is a comment around the code that says it has explicitely been disabled, but most of my usage would be around servers which only do gss negotiate.
It would be much simpler to just use CURLAUTH_ANY but as I do not know of any server with the described problem I cannot test if it is still relevant, so a new option seems safer.
This also adds two new messages that I have left in English for Portugese, Polish and Russian as I do not speak these.

Thanks!