### PR TITLE
Fix spelling errors found by Debian's Lintian

### DIFF
--- a/doc/man-edbrowse-debian.1
+++ b/doc/man-edbrowse-debian.1
@@ -108,10 +108,10 @@ which prints the sizes of buffers. Some people like 2 which prints
 out URLs as they are retrieved. This value can be changed within the 
 editor with the
 .I dbx
-command with x a value betwen 0 and 9.
+command with x a value between 0 and 9.
 .TP
 .B \-c
-Edit config file. This command supresses the processing of the
+Edit config file. This command suppresses the processing of the
 configuration file
 .I $HOME/.ebrc
 and starts editing it instead. This option is useful if this file

--- a/lang/msg-en
+++ b/lang/msg-en
@@ -224,7 +224,7 @@ buffer %d contains more than one line
 cannot open %s
 cannot read from %s
 input text contains nulls
-line contains an embeded carriage return
+line contains an embedded carriage return
 first line of %s is too long
 file is currently in buffer - please use the rf command to refresh
 cannot browse a binary file
@@ -414,7 +414,7 @@ the data contains newlines
 line contains too many fields, please do not introduce any pipes into the text
 line contains too few fields, please do not remove any pipes from the text
 no primary key column for this table
-miscelaneous sql error %d
+miscellaneous sql error %d
 cannot delete more than 100 rows at a time
 cannot change a key column
 cannot change a blob field

--- a/lang/msg-ru
+++ b/lang/msg-ru
@@ -224,7 +224,7 @@ buffer %d contains more than one line
 cannot open %s
 cannot read from %s
 input text contains nulls
-line contains an embeded carriage return
+line contains an embedded carriage return
 first line of %s is too long
 file is currently in buffer - please use the rf command to refresh
 cannot browse a binary file
@@ -414,7 +414,7 @@ the data contains newlines
 line contains too many fields, please do not introduce any pipes into the text
 line contains too few fields, please do not remove any pipes from the text
 no primary key column for this table
-miscelaneous sql error %d
+miscellaneous sql error %d
 cannot delete more than 100 rows at a time
 cannot change a key column
 cannot change a blob field

--- a/src/buffers.c
+++ b/src/buffers.c
@@ -4343,7 +4343,7 @@ Run the entered edbrowse command.
 This is indirectly recursive, as in g/x/d
 Pass in the ed command, and return success or failure.
 We assume it has been turned into a C string.
-This means no embeded nulls.
+This means no embedded nulls.
 If you want to use null in a search or substitute, use \0.
 *********************************************************************/
 

--- a/src/dbapi.h
+++ b/src/dbapi.h
@@ -80,7 +80,7 @@ By designating a couple of these exception codes,
 the application can direct error recovery at a high level.
 *********************************************************************/
 
-#define EXCSQLMISC 1		/* miscelaneous SQL errors not covered below */
+#define EXCSQLMISC 1		/* miscellaneous SQL errors not covered below */
 #define EXCSYNTAX 2		/* syntax error in SQL statement */
 #define EXCFILENAME 3		/* this filename cannot be used by SQL */
 #define EXCCONVERT 4		/* cannot convert/compare the columns/constants in the SQL statement */

--- a/src/dbops.c
+++ b/src/dbops.c
@@ -25,7 +25,7 @@ bool rv_blobAppend;
 /* text descriptions corresponding to our generic SQL error codes */
 /* This has yet to be internationalized. */
 const char *sqlErrorList[] = { 0,
-	"miscelaneous SQL error",
+	"miscellaneous SQL error",
 	"syntax error in SQL statement",
 	"filename cannot be used by SQL",
 	"cannot convert/compare the columns/constants in the SQL statement",


### PR DESCRIPTION
Debian has been carrying this patch so I'm forwarding upstream.