### PR TITLE
build and iInstall man page, and usersguide.html

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,28 @@ else ()
 endif ()
 
 ###########################################################
+### 20180415 - Add man page gen, and install - also doc/usersguide.html
+if (UNIX)
+    # copy to build dir
+    configure_file( doc/man-edbrowse-debian.1 ${CMAKE_BINARY_DIR}/edbrowse.1 )
+    # find 'gzip' - warn if not...
+    find_program(GZIP_EXE gzip PATHS /bin )
+    if (GZIP_EXE)
+        # gzip it in place
+        execute_process(COMMAND ${GZIP_EXE} -f "edbrowse.1"
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            INPUT_FILE edbrowse.1
+            OUTPUT_FILE edbrowse.1.gz )
+        # install it
+        install(FILES ${CMAKE_BINARY_DIR}/edbrowse.1.gz DESTINATION "/usr/share/man/man1")
+    else ()
+        message(WARNING "Unable to locate 'gzip'! No man page...")
+    endif ()
+    # install user guide
+    install(FILES doc/usersguide.html DESTINATION "/usr/share/doc/edbrowse")
+endif ()
+
+###########################################################
 ### edbr static library of shared source - not currently used.
 #  set(name edbr-lib)
 #  set(dir src)

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -17,4 +17,6 @@ COMMENTS.txt
 *.opensdf
 *.suo
 ipch/*
+edbrowse.*
+install_manifest.txt
 

--- a/build/cmake-clean.txt
+++ b/build/cmake-clean.txt
@@ -1,1 +1,6 @@
 bldlog-1.txt
+edbrowse
+edbrowse.1
+edbrowse.1.gz
+install_manifest.txt
+


### PR DESCRIPTION
Need someone with more unix experience to checkout this cmake change...

After install, `man edbrowse` seem to work for me, and the usersguide.html is copied to the specified directory...
