### PR TITLE
Fix build with curl 7.62.0

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1557,7 +1557,9 @@ void ebcurl_setError(CURLcode curlret, const char *url, int action,
 		break;
 
 	case CURLE_PEER_FAILED_VERIFICATION:
+#if LIBCURL_VERSION_NUM < 0x073e00
 	case CURLE_SSL_CACERT:
+#endif
 		(*fn) (MSG_NoCertify, host);
 		break;
 


### PR DESCRIPTION
from CHANGES:
ssl: deprecate CURLE_SSL_CACERT in favour of a unified error code
Long live CURLE_PEER_FAILED_VERIFICATION