### PR TITLE
Fix FreeBSD linking

### DIFF
--- a/CMakeModules/FindTidy.cmake
+++ b/CMakeModules/FindTidy.cmake
@@ -25,6 +25,9 @@ if (_TIDY_ROOT)
 endif ()
 
 set(TIDY_NAMES tidy)
+if (${CMAKE_SYSTEM_NAME} STREQUAL  "FreeBSD")
+    set(TIDY_NAMES tidy5)
+endif ()
 
 if (_TIDY_SEARCHES)
     # Try each search configuration.


### PR DESCRIPTION
This fix linking in FreeBSD
FreeBSD has 2 libtidy, edbrowse uses libtidy5