### PR TITLE
Fix cookie handling for recent curl.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -2167,6 +2167,10 @@ static CURL *http_curl_init(struct i_get *g)
 	    curl_easy_setopt(h, CURLOPT_SHARE, global_share_handle);
 	if (curl_init_status != CURLE_OK)
 		goto libcurl_init_fail;
+	curl_init_status = curl_easy_setopt(h, CURLOPT_COOKIEFILE, "");
+	if (curl_init_status != CURLE_OK) {
+		goto libcurl_init_fail;
+	}
 /* Lots of these setopt calls shouldn't fail.  They just diddle a struct. */
 	curl_easy_setopt(h, CURLOPT_SOCKOPTFUNCTION, my_curl_safeSocket);
 	curl_easy_setopt(h, CURLOPT_WRITEFUNCTION, eb_curl_callback);

--- a/src/main.c
+++ b/src/main.c
@@ -228,6 +228,12 @@ void eb_curl_global_init(void)
 		goto libcurl_init_fail;
 	if (cookieFile && !ismc) {
 		curl_init_status =
+		    curl_easy_setopt(global_http_handle, CURLOPT_COOKIEFILE,
+				     "");
+		if (curl_init_status != CURLE_OK) {
+			goto libcurl_init_fail;
+		}
+		curl_init_status =
 		    curl_easy_setopt(global_http_handle, CURLOPT_COOKIEJAR,
 				     cookieFile);
 		if (curl_init_status != CURLE_OK)


### PR DESCRIPTION
Commit d0a7ee3f613b0c3f2370c6cc81e5aafef67120f0 from the curl project
made it so that we need to enable the cookie engine for each of the
curl_easy handles that needed it.  Once isn't good enough
So now we do that, for all of our HTTP handles.