### PR TITLE
Be really aggressive about setting close-on-exec.

### DIFF
--- a/src/buffers.c
+++ b/src/buffers.c
@@ -334,7 +334,7 @@ void passToJdb(char *s)
 	cf = cw->jdb_frame;
 	result = jsRunScriptWinResult(s, "jdb", 1);
 	if (resfile)
-		f = fopen(resfile, "w");
+		f = fopen(resfile, "we");
 	if (result) {
 		if (f) {
 			fprintf(f, "%s\n", result);
@@ -2284,6 +2284,7 @@ bool writeFile(const char *name, int mode)
 	if (cw->binMode | cw->utf16Mode | cw->utf32Mode)
 		stringAndChar(&modeString, &modeString_l, 'b');
 
+	stringAndChar(&modeString, &modeString_l, 'e'); // O_CLOEXEC
 	fh = fopen(name, modeString);
 	nzFree(modeString);
 	if (fh == NULL) {
@@ -7789,7 +7790,7 @@ doquit:
 // W command must write to a temp file, then read back in
 			if(wrc)
 				ignore = asprintf(&wrapline, "( %s ) > %s", newline, wrc_file);
-			p = popen(wrapline ? wrapline : newline, "w");
+			p = popen(wrapline ? wrapline : newline, "we");
 			nzFree(wrapline);
 			nzFree(newline);
 			if (!p) {
@@ -8476,7 +8477,7 @@ past_js:
 		char *newline = bangbang(line + 1);
 		eb_variables();
 		newline = apostropheMacros(newline);
-		p = popen(newline, "r");
+		p = popen(newline, "re");
 		nzFree(newline);
 		if (!p) {
 			setError(MSG_NoSpawn, line + 1, errno);

--- a/src/css.c
+++ b/src/css.c
@@ -413,7 +413,7 @@ void writeShortCache(void)
 	struct cssmaster *cm = cf->cssmaster;
 	if (!cm)
 		return;
-	f = fopen("implocal", "w");
+	f = fopen("implocal", "we");
 	if (!f)
 		return;
 	for (c = cm->cache; c; c = c->next) {
@@ -433,7 +433,7 @@ void writeShortCache(void)
 
 static void readShortCache(struct cssmaster *cm)
 {
-	FILE *f = fopen("implocal", "r");
+	FILE *f = fopen("implocal", "re");
 	struct shortcache *c;
 	char *s;
 	int length, n = 0;
@@ -1689,7 +1689,7 @@ void cssDocLoad(int frameNumber, char *start, bool pageload)
 	if (!cm->descriptors)
 		goto done;
 	if (debugCSS) {
-		FILE *f = fopen(cssDebugFile, "a");
+		FILE *f = fopen(cssDebugFile, "ae");
 		if (f) {
 			fprintf(f, "%s end\n", errorMessage[CSS_ERROR_DELIM]);
 			fclose(f);
@@ -1824,7 +1824,7 @@ static void cssPiecesPrint(const struct desc *d)
 
 	if (!debugCSS)
 		return;
-	cssfile = fopen(cssDebugFile, "a");
+	cssfile = fopen(cssDebugFile, "ae");
 	if (!cssfile)
 		return;
 	if (!d) {
@@ -2604,7 +2604,7 @@ static bool qsaMatchGroup(Tag *t, struct desc *d)
 		return false;
 	d->highspec = 0;
 	if (debugCSS)
-		f = fopen(cssDebugFile, "a");
+		f = fopen(cssDebugFile, "ae");
 	for (sel = d->selectors; sel; sel = sel->next) {
 		if (sel->error)
 			continue;
@@ -3380,7 +3380,7 @@ static void hashPrint(void)
 	int i;
 	if (!debugCSS)
 		return;
-	f = fopen(cssDebugFile, "a");
+	f = fopen(cssDebugFile, "ae");
 	if (!f)
 		return;
 	fprintf(f, "nodes %d\n", doclist_n);

--- a/src/dbodbc.c
+++ b/src/dbodbc.c
@@ -704,7 +704,7 @@ sql_blobInsert(const char *tabname, const char *colname, int rowid,
 			    ("2blobInsert is given null filename and null buffer");
 	} else {
 		offset = blobbuf;
-		fd = eopen(filename, O_RDONLY | O_BINARY, 0);
+		fd = eopen(filename, O_RDONLY | O_BINARY | O_CLOEXEC, 0);
 		length = fileSizeByHandle(fd);
 		if (length == 0) {
 			isfile = false;
@@ -1046,7 +1046,7 @@ static void retsFromOdbc(void)
 			flags = O_WRONLY | O_BINARY | O_CREAT | O_TRUNC;
 			if (rv_blobAppend)
 				flags =
-				    O_WRONLY | O_BINARY | O_CREAT | O_APPEND;
+				    O_WRONLY | O_BINARY | O_CREAT | O_APPEND | O_CLOEXEC;
 			fd = eopen(rv_blobFile, flags, MODE_rw);
 			rc = SQL_SUCCESS;
 			while (true) {

--- a/src/fetchmail.c
+++ b/src/fetchmail.c
@@ -122,7 +122,7 @@ static void writeAttachment(struct MHINFO *w)
 		}
 	} else if (!stringEqual(atname, "x")) {
 		int fh =
-		    open(atname, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC,
+		    open(atname, O_WRONLY | O_BINARY | O_CREAT | O_TRUNC | O_CLOEXEC,
 			 MODE_rw);
 		if (fh < 0) {
 			i_printf(MSG_AttNoSave, atname);
@@ -1009,7 +1009,7 @@ You'll see this after the perform function runs.
 	}
 afterfetch:
 #if 0
-	t = 0; FILE *z; z = fopen("msb", "w"); fprintf(z, "%s", mailstring); fclose(z);
+	t = 0; FILE *z; z = fopen("msb", "we"); fprintf(z, "%s", mailstring); fclose(z);
 #endif
 
 // have to strip fetch BODY line off the front,
@@ -1500,7 +1500,7 @@ range:
 	res = getMailData(handle);
 	if (res != CURLE_OK) goto abort;
 #if 0
-	FILE *z; z = fopen("ms1", "w"); fprintf(z, "%s", mailstring); fclose(z);
+	FILE *z; z = fopen("ms1", "we"); fprintf(z, "%s", mailstring); fclose(z);
 #endif
 
 	t = mailstring;
@@ -1568,7 +1568,7 @@ abort:
 		return false;
 	}
 #if 0
-	FILE *z; z = fopen("ms2", "w"); fprintf(z, "%s", mailstring); fclose(z);
+	FILE *z; z = fopen("ms2", "we"); fprintf(z, "%s", mailstring); fclose(z);
 #endif
 
 // Don't free mailstring, we're using pieces of it
@@ -1947,7 +1947,7 @@ static CURLcode fetchOneMessage(CURL * handle, int message_number)
 
 /* got the file, save it in unread */
 	sprintf(umf_end, "%d", unreadMax + message_number);
-	umfd = open(umf, O_WRONLY | O_TEXT | O_CREAT, MODE_rw);
+	umfd = open(umf, O_WRONLY | O_TEXT | O_CREAT | O_CLOEXEC, MODE_rw);
 	if (umfd < 0)
 		i_printfExit(MSG_NoCreate, umf);
 	if (write(umfd, mailstring, mailstring_l) < mailstring_l)
@@ -2336,7 +2336,7 @@ static void saveRawMail(const char *buf, int length)
 		sprintf(rmf, "%s/%05d", mailStash, rn);
 		if (fileTypeByName(rmf, 0)) continue;
 // dump the original mail into the file
-		rmfh =     open(rmf,  O_WRONLY | O_TEXT | O_CREAT | O_APPEND,  MODE_rw);
+		rmfh =     open(rmf,  O_WRONLY | O_TEXT | O_CREAT | O_APPEND | O_CLOEXEC,  MODE_rw);
 		if (rmfh < 0)
 			break;
 		if (write(rmfh, buf, length) <     length) {
@@ -2564,7 +2564,7 @@ saveMail:
 		goto afterinput;
 
 	exists = fileTypeByName(atname, 0);
-	fh = open(atname, O_WRONLY | O_TEXT | O_CREAT | O_APPEND, MODE_rw);
+	fh = open(atname, O_WRONLY | O_TEXT | O_CREAT | O_APPEND | O_CLOEXEC, MODE_rw);
 	if (fh < 0) {
 		i_printf(MSG_NoCreate, atname);
 		atname = 0;
@@ -3992,7 +3992,7 @@ static void writeReplyInfo(const char *addstring)
 {
 	int rfh;		/* reply file handle */
 	if(!mailReply) return;
-	rfh = open(mailReply, O_WRONLY | O_APPEND | O_CREAT, MODE_private);
+	rfh = open(mailReply, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, MODE_private);
 	if (rfh < 0)
 		return;
 	ignore = write(rfh, addstring, 12);
@@ -4032,7 +4032,7 @@ static void readReplyInfo(void)
 found:
 /* prestring is the key */
 	sprintf(prestring, "%05d.%05d:", major, minor);
-	rfh = open(mailReply, O_RDONLY);
+	rfh = open(mailReply, O_RDONLY | O_CLOEXEC);
 	if (rfh < 0)
 		return;
 	if (!fdIntoMemory(rfh, &buf, &buflen, 0))
@@ -4843,7 +4843,7 @@ saveMail:
 	if (stringEqual(name, "x"))
 		return true;
 	exists = fileTypeByName(name, 0);
-	fh = open(name, O_WRONLY | O_TEXT | O_CREAT | O_APPEND, MODE_rw);
+	fh = open(name, O_WRONLY | O_TEXT | O_CREAT | O_APPEND | O_CLOEXEC, MODE_rw);
 	if (fh < 0) {
 		i_printf(MSG_NoCreate, name);
 		name = 0;

--- a/src/http.c
+++ b/src/http.c
@@ -2152,7 +2152,7 @@ Custom headers to upload to a different name, and then rename the local file.
 We don't need to do that either.
 *********************************************************************/
 
-	f = fopen(tempfile, (cw->binMode ? "rb" : "r"));
+	f = fopen(tempfile, (cw->binMode ? "rbe" : "re"));
 	if(!f) { // this should never happen
 		setError(MSG_NoOpen, tempfile, strerror(errno));
 		goto fail;

--- a/src/jseng-quick.c
+++ b/src/jseng-quick.c
@@ -1709,7 +1709,7 @@ static JSValue nat_wlf(JSContext * cx, JSValueConst this, int argc, JSValueConst
 	}
 	if (!safe)
 		goto done;
-	fh = open(filename, O_CREAT | O_TRUNC | O_WRONLY | O_TEXT, MODE_rw);
+	fh = open(filename, O_CREAT | O_TRUNC | O_WRONLY | O_TEXT | O_CLOEXEC, MODE_rw);
 	if (fh < 0) {
 		printf("cannot create file %s\n", filename);
 		goto done;

--- a/src/main.c
+++ b/src/main.c
@@ -1896,7 +1896,7 @@ inside:
 			ftype = fileTypeByName(v, 0);
 			if (ftype && ftype != 'f')
 				cfgAbort1(MSG_EBRC_JarNotFile, v);
-			j = open(v, O_WRONLY | O_APPEND | O_CREAT,
+			j = open(v, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC,
 				 MODE_private);
 			if (j < 0)
 				cfgAbort1(MSG_EBRC_JarNoWrite, v);
@@ -1935,7 +1935,7 @@ inside:
 			ftype = fileTypeByName(v, 0);
 			if (ftype && ftype != 'f')
 				cfgAbort1(MSG_EBRC_SSLNoFile, v);
-			j = open(v, O_RDONLY);
+			j = open(v, O_RDONLY | O_CLOEXEC);
 			if (j < 0)
 				cfgAbort1(MSG_EBRC_SSLNoRead, v);
 			close(j);
@@ -2064,7 +2064,7 @@ inside:
 			ftype = fileTypeByName(v, 0);
 			if (ftype && ftype != 'f')
 				cfgAbort1(MSG_EBRC_KeyNoFile, v);
-			j = open(v, O_RDONLY);
+			j = open(v, O_RDONLY | O_CLOEXEC);
 			if (j < 0)
 				cfgAbort1(MSG_EBRC_KeyNoRead, v);
 			close(j);
@@ -2317,7 +2317,7 @@ const char *fetchReplace(const char *u)
 
 static void loadReplacements(void)
 {
-	FILE *f = fopen("jslocal", "r");
+	FILE *f = fopen("jslocal", "re");
 	struct JSR *j;
 	char *s;
 	int n = 0;

--- a/src/sendmail.c
+++ b/src/sendmail.c
@@ -485,7 +485,7 @@ empty:
 				n = fileSizeByName(sigFile);
 				if (n > 0) {
 					buf = reallocMem(buf, buflen + n + 1);
-					fd = open(sigFile, O_RDONLY);
+					fd = open(sigFile, O_RDONLY | O_CLOEXEC);
 					if (fd < 0) {
 						setError(MSG_SigAccess);
 						goto freefail;


### PR DESCRIPTION
I did this for libcurl sockets a long long time ago.
But there are tons of other places where we aren't, and should
be, using close-on-exec.  For instance, if you shell out to
something, there is no earthly reason why the kiddo and
whatever descendents it may have should have FDs pointing
at edbrowse's cache control files and suchlike.
So let's be really really aggressive.

fopen has an e mode for this; open has O_CLOEXEC.
Note that fopen seems to be really picky about where the e
goes in the modestring.  Apparently it must always come at
the end.

This was a bit of a naive search-and-replace.  Not
particularly well-tested, though things appear fine.
