### PR TITLE
Support for type="module" in script tags

### DIFF
--- a/src/ebprot.h
+++ b/src/ebprot.h
@@ -503,7 +503,7 @@ void run_function_onestring_t(const Tag *t, const char *name, const char *s);
 char *run_function_onestring1_t(const Tag *t, const char *name, const char *s);
 void run_function_twostring_t(const Tag *t, const char *name, const char *s1, const char *s2);
 void run_function_onestring_win(const Frame *f, const char *name, const char *s);
-void jsRunData(const Tag *t, const char *filename, int lineno);
+void jsRunData(const Tag *t, const char *filename, int lineno, bool is_module);
 bool run_event_t(const Tag *t, const char *evname);
 bool run_event_win(const Frame *f, const char *evname);
 bool run_event_doc(const Frame *f, const char *evname);

--- a/src/html.c
+++ b/src/html.c
@@ -1127,97 +1127,94 @@ bool isRooted(const Tag *t)
 
 void runScriptNow(Frame *runframe, Tag *t)
 {
-	const char *a; // for attribute
-	const char *gc_name; // garbage collection name
-	const char *sourcefile;
-	int ln; // line number
+    const char *a; // for attribute
+    const char *gc_name; // garbage collection name
+    const char *sourcefile;
+    int ln; // line number
+    bool is_module;
+    t->step = 5; // now running the script
+    set_property_number_t(t, "eb$step", 5);
 
-	t->step = 5; // now running the script
-	set_property_number_t(t, "eb$step", 5);
-
-	if (t->inxhr) {
+    if (t->inxhr) {
 // xhr looks like an asynchronous script.
-		run_function_bool_t(t, "parseResponse");
+        run_function_bool_t(t, "parseResponse");
 /*********************************************************************
 Ok this is subtle. I put it on a script tag, and t.jv.onload exists!
 That is the function that is run by xhr.
 So runOnload() comes along and runs it again, unless we do something.
 I will disconnect here, and also check for inxhr in runOnload().
 	*********************************************************************/
-		disconnectTagObject(t);
-		t->dead = true;
+        disconnectTagObject(t);
+        t->dead = true;
 // allow garbage collection to recapture the object if it wants to
-		gc_name = get_property_string_t(t, "backlink");
-		if (gc_name)
-			delete_property_win(cf, gc_name);
-		cnzFree(gc_name);
-		return;
-	}
+        gc_name = get_property_string_t(t, "backlink");
+        if (gc_name) delete_property_win(cf, gc_name);
+        cnzFree(gc_name);
+        return;
+    }
 
 // If no language is specified, javascript is default.
-	a = get_property_string_t(t, "language");
-	if (a && *a && (!memEqualCI(a, "javascript", 10) || isalphaByte(a[10]))) {
-		debugPrint(3, "script tag %d language %s not executed", t->seqno, a);
-		cnzFree(a);
-		return;
-	}
-	cnzFree(a);
+    a = get_property_string_t(t, "language");
+    if (a && *a && (!memEqualCI(a, "javascript", 10) || isalphaByte(a[10]))) {
+        debugPrint(3, "script tag %d language %s not executed", t->seqno, a);
+        cnzFree(a);
+        return;
+    }
+    cnzFree(a);
 // Also reject a script if a type is specified and it is not JS.
 // For instance, some JSON pairs in script tags on amazon.com
-	a = get_property_string_t(t, "type");
+    a = get_property_string_t(t, "type");
 // allow for type 5e5857709a179301c738ca91-text/javascript, which really happens.
 // Also application/javascript.
-	if (a && *a && !stringEqualCI(a, "javascript") &&
-	((ln = strlen(a)) < 11 || !stringEqualCI(a + ln - 11, "/javascript"))) {
-		debugPrint(3, "script tag %d type %s not executed", t->seqno, a);
-		cnzFree(a);
-		return;
-	}
-	cnzFree(a);
+    is_module = (a && *a && stringEqualCI(a, "module"));
+    if (!is_module && a && *a && !stringEqualCI(a, "javascript") &&
+        ((ln = strlen(a)) < 11 || !stringEqualCI(a + ln - 11, "/javascript"))
+    ) {
+        debugPrint(3, "script tag %d type %s not executed", t->seqno, a);
+        cnzFree(a);
+        return;
+    }
+    cnzFree(a);
 
-	sourcefile = t->js_file;
-	if (!sourcefile) sourcefile = "generated";
-	ln = t->js_ln;
-	if (!ln) ln = 1;
-	if (cf != runframe)
-		debugPrint(4, "running script at a lower frame %s",
-		sourcefile);
-	debugPrint(3, "exec %s at %d", sourcefile, ln);
-	jsRunData(t, sourcefile, ln);
-	debugPrint(3, "exec complete");
+     sourcefile = t->js_file;
+    if (!sourcefile) sourcefile = "generated";
+    ln = t->js_ln;
+    if (!ln) ln = 1;
+    if (cf != runframe)
+        debugPrint(4, "running script at a lower frame %s", sourcefile);
+    debugPrint(3, "exec %s at %d", sourcefile, ln);
+    jsRunData(t, sourcefile, ln, is_module);
+    debugPrint(3, "exec complete");
 
 // Last step, look for document.write from this script
-	if (!cf->dw) return;
+    if (!cf->dw) return;
 // completely different behavior before and after browse
 // After browse, it clobbers the page.
-	if(cf->browseMode && ! cf->dw_clobber) {
-		debugPrint(3, "document.write clobber 1");
-		run_function_onestring_t(cf->bodytag, "eb$dbih",
-		strstr(cf->dw, "<body>")+6);
+    if(cf->browseMode && ! cf->dw_clobber) {
+        debugPrint(3, "document.write clobber 1");
+        run_function_onestring_t(cf->bodytag, "eb$dbih",
+            strstr(cf->dw, "<body>")+6);
 		cf->dw_clobber = true;
-	} else {
+    } else {
 // Any newly generated scripts have to run next. Move them up in the linked list.
-		Tag *t1, *t2, *u;
-		for(u = t; u; u = u->same)
-			t1 = u;
+        Tag *t1, *t2, *u;
+        for (u = t; u; u = u->same) t1 = u;
 // t1 is now last real script in the list.
-		stringAndString(&cf->dw, &cf->dw_l, "</body>");
-		runGeneratedHtml(t, cf->dw);
-		run_function_onearg_win(cf, "eb$uplift", t);
-		for(u = t1; u; u = u->same)
-			t2 = u;
-		if(t1 != t && t2 != t1) {
-			Tag *t3 = t->same;
-			t->same = t1->same;
-			t2->same = t3;
-			t1->same = 0;
-			for(u = t->same; u != t3; u = u->same)
-				if(u->jslink)
-					loadScriptData(u);
-		}
-	}
-	nzFree0(cf->dw);
-	cf->dw_l = 0;
+        stringAndString(&cf->dw, &cf->dw_l, "</body>");
+        runGeneratedHtml(t, cf->dw);
+        run_function_onearg_win(cf, "eb$uplift", t);
+        for (u = t1; u; u = u->same) t2 = u;
+        if(t1 != t && t2 != t1) {
+            Tag *t3 = t->same;
+            t->same = t1->same;
+            t2->same = t3;
+            t1->same = 0;
+            for (u = t->same; u != t3; u = u->same)
+                if (u->jslink) loadScriptData(u);
+        }
+    }
+    nzFree0(cf->dw);
+    cf->dw_l = 0;
 }
 
 static void runOnload(void);
@@ -1240,9 +1237,9 @@ void runScriptsPending(bool startbrowse)
 		if(cf->browseMode && !cf->dw_clobber) {
 			debugPrint(3, "document.write clobber 2");
 			run_function_onestring_t(cf->bodytag, "eb$dbih",
-			strstr(cf->dw, "<body>")+6);
-			cf->dw_clobber = true;
-		} else {
+            strstr(cf->dw, "<body>")+6);
+            cf->dw_clobber = true;
+        } else {
 			stringAndString(&cf->dw, &cf->dw_l, "</body>");
 			runGeneratedHtml(cf->bodytag, cf->dw);
 		}
@@ -4249,6 +4246,7 @@ static void runTimer0(struct jsTimer *jt, const Frame *save_cf)
 		if (t->step == 4 && t->action == TAGACT_SCRIPT) {
 			char *sourcefile = t->js_file;
 			int ln = t->js_ln;
+                        const char *a = get_property_string_t(t, "type");
 			t->step = 5;	// running
 			if (!sourcefile) sourcefile = "generated";
 			if (!ln) ln = 1;
@@ -4259,7 +4257,9 @@ static void runTimer0(struct jsTimer *jt, const Frame *save_cf)
 					   sourcefile);
 			debugPrint(3, "async exec timer %d %s at %d",
 				   jt->tsn, sourcefile, ln);
-			jsRunData(t, sourcefile, ln);
+			jsRunData(t, sourcefile, ln,
+                                (a && *a && stringEqualCI(a, "module")));
+                        cnzFree(a);
 			debugPrint(3, "async exec complete");
 		}
 		if (t->step == 4 && t->action != TAGACT_SCRIPT) {

--- a/src/jseng-quick.c
+++ b/src/jseng-quick.c
@@ -154,6 +154,7 @@ static void grabover(void)
 
 const char *jsSourceFile;	// sourcefile providing the javascript
 int jsLineno;			// line number
+static int js_eval_flag = JS_EVAL_TYPE_GLOBAL; // global, module etc
 static JSRuntime *jsrt;
 static bool js_running;
 static JSContext *mwc; // master window context
@@ -1142,87 +1143,73 @@ static 	const char *trace_string =
 	  ";(function(arg$,l$ne){ var t$t=trace$ch(l$ne); if(t$t == 0) return; if(t$t == 1) { alert3(step$val); return; } alert('break at line ' + step$val); while(true){var res = prompt('bp'); if(!res) continue; if(res === '.') break; try { res = eval(res); alert(res); } catch(e) { alert(e.toString()); }}}).call(this,(typeof arguments=='object'?arguments:[]),\"";
 static char *run_script(JSContext *cx, const char *s)
 {
-	char *result = 0;
-	JSValue r;
-	char *s2 = 0;
-	const char *s3;
-	const char *ebnobp = getenv("EBNOBP");
-	int commapresent;
+    char *result = NULL;
+    JSValue r;
+    char *s2 = NULL;
+    const char *s3;
+    const char *ebnobp = getenv("EBNOBP");
+    int commapresent;
 
 // special debugging code to replace bp@ and trace@ with expanded macros.
 // Warning: breakpoints and tracing can change the flow of execution
 // in unusual cases, e.g. when a js verifyer checks f.toString(),
 // and of course it will be very different with the debugging stuff in it.
-	if((!ebnobp || !*ebnobp) &&
-	(strstr(s, "bp@(") || strstr(s, "trace@("))) {
-		int l;
-		const char *u, *v1, *v2;
-
-		s2 = initString(&l);
-		u = s;
-		while (true) {
-			v1 = strstr(u, "bp@(");
-			v2 = strstr(u, "trace@(");
-			if (v1 && v2 && v2 < v1)
-				v1 = v2;
-			if (!v1)
-				v1 = v2;
-			if (!v1)
-				break;
-			stringAndBytes(&s2, &l, u, v1 - u);
+    if ((!ebnobp || !*ebnobp) && (strstr(s, "bp@(") || strstr(s, "trace@("))) {
+        int l;
+        const char *u, *v1, *v2;
+        s2 = initString(&l);
+        u = s;
+        while (true) {
+            v1 = strstr(u, "bp@(");
+            v2 = strstr(u, "trace@(");
+            if (v1 && v2 && v2 < v1) v1 = v2;
+            if (!v1) v1 = v2;
+            if (!v1) break;
+            stringAndBytes(&s2, &l, u, v1 - u);
 
 // The macros for bp and trace start and end with ;
 // That keeps them separate from what goes on around them.
 // But it also makes it impossible to write exp,exp,bp@(huh),exp
 // watch for comma on either side, and if so, omit the ;
 
-			while(l && s2[l-1] == ' ')
-				s2[--l] = 0;
-			commapresent = (l && s2[l-1] == ',');
-
-			stringAndString(&s2, &l, (*v1 == 'b' ?
-			bp_string + commapresent
-			  :
-			trace_string + commapresent
-			) );
+            while(l && s2[l-1] == ' ') s2[--l] = 0;
+            commapresent = (l && s2[l-1] == ',');
+            stringAndString(&s2, &l, (
+                *v1 == 'b' ?
+                bp_string + commapresent :
+                trace_string + commapresent));
 
 // paste in the argument to bp@(x) or trace@(x)
-			v1 = strchr(v1, '(') + 1;
-			v2 = strchr(v1, ')');
-			stringAndBytes(&s2, &l, v1, v2 - v1);
-			stringAndString(&s2, &l, "\");");
-
-			u = ++v2;
-			while(*u == ' ') ++u;
-			if(*u == ',' || *u == ';') {
+            v1 = strchr(v1, '(') + 1;
+            v2 = strchr(v1, ')');
+            stringAndBytes(&s2, &l, v1, v2 - v1);
+            stringAndString(&s2, &l, "\");");
+            u = ++v2;
+            while(*u == ' ') ++u;
 // commapresent on the other side, don't need trailing ;
-				s2[--l] = 0;
-			}
-		}
-		stringAndString(&s2, &l, u);
-	}
+            if(*u == ',' || *u == ';') s2[--l] = 0;
 
-	s3 = (s2 ? s2 : s);
-	r = JS_Eval(cx, s3, strlen(s3),
-	(jsSourceFile ? jsSourceFile : "internal"), JS_EVAL_TYPE_GLOBAL);
-	grab(r);
-	nzFree(s2);
-	if (intFlag)
-		i_puts(MSG_Interrupted);
-	if(!JS_IsException(r)) {
-		s = JS_ToCString(cx, r);
-		if(s && *s)
-			result = cloneString(s);
-		JS_FreeCString(cx, s);
-	} else {
-		processError(cx);
-	}
-	JS_Release(cx, r);
-	return result;
+        }
+        stringAndString(&s2, &l, u);
+    }
+
+    s3 = (s2 ? s2 : s);
+    r = JS_Eval(cx, s3, strlen(s3),
+        (jsSourceFile ? jsSourceFile : "internal"), js_eval_flag);
+    grab(r);
+    nzFree(s2);
+    if (intFlag) i_puts(MSG_Interrupted);
+    if (!JS_IsException(r)) {
+        s = JS_ToCString(cx, r);
+        if(s && *s) result = cloneString(s);
+        JS_FreeCString(cx, s);
+    } else processError(cx);
+    JS_Release(cx, r);
+    return result;
 }
 
 // execute script.text code; more efficient than the above.
-void jsRunData(const Tag *t, const char *filename, int lineno)
+void jsRunData(const Tag *t, const char *filename, int lineno, bool is_module)
 {
 	JSValue v;
 	const char *s;
@@ -1233,6 +1220,7 @@ void jsRunData(const Tag *t, const char *filename, int lineno)
 	cx = t->f0->cx;
 	jsSourceFile = filename;
 	jsLineno = lineno;
+        if (is_module) js_eval_flag = JS_EVAL_TYPE_MODULE;
 	v = JS_GetPropertyStr(cx, *((JSValue*)t->jv), "text");
 	grab(v);
 	if(!JS_IsString(v)) {
@@ -1261,7 +1249,7 @@ void jsRunData(const Tag *t, const char *filename, int lineno)
 		nzFree(result);
 	} else {
 		JSValue r = JS_Eval(cx, s, strlen(s),
-		(jsSourceFile ? jsSourceFile : "internal"), JS_EVAL_TYPE_GLOBAL);
+		(jsSourceFile ? jsSourceFile : "internal"), js_eval_flag);
 		grab(r);
 		if (intFlag)
 			i_puts(MSG_Interrupted);
@@ -1271,6 +1259,7 @@ void jsRunData(const Tag *t, const char *filename, int lineno)
 	}
 	JS_FreeCString(cx, s);
 	jsSourceFile = NULL;
+        js_eval_flag = JS_EVAL_TYPE_GLOBAL;
 	delete_property(cx, *((JSValue*)t->f0->docobj), "currentScript");
 // onload handler? Should this run even if the script fails?
 // Right now it does.
@@ -1283,38 +1272,34 @@ void jsRunData(const Tag *t, const char *filename, int lineno)
 // Run some javascript code under the named object, usually window.
 // Pass the return value of the script back as a string.
 static char *jsRunScriptResult(const Frame *f, const char *str,
-const char *filename, 			int lineno)
+const char *filename, int lineno)
 {
-	char *result;
-	if (!allowJS || !f->jslink)
-		return NULL;
-	if (!str || !str[0])
-		return NULL;
-	debugPrint(5, "> script:");
-	jsSourceFile = filename;
-	jsLineno = lineno;
-	result = run_script(f->cx, str);
-	jsSourceFile = NULL;
-	debugPrint(5, "< ok");
-	return result;
+    char *result;
+    if (!allowJS || !f->jslink) return NULL;
+    if (!str || !str[0]) return NULL;
+    debugPrint(5, "> script:");
+    jsSourceFile = filename;
+    jsLineno = lineno;
+    result = run_script(f->cx, str);
+    jsSourceFile = NULL;
+    debugPrint(5, "< ok");
+    return result;
 }
 
 /* like the above but throw away the result */
-void jsRunScriptWin(const char *str, const char *filename, 		 int lineno)
+void jsRunScriptWin(const char *str, const char *filename, int lineno)
 {
-	char *s = jsRunScriptResult(cf, str, filename, lineno); 	nzFree(s);
+    nzFree(jsRunScriptResult(cf, str, filename, lineno));
 }
 
-void jsRunScript_t(const Tag *t, const char *str, const char *filename, 		 int lineno)
+void jsRunScript_t(const Tag *t, const char *str, const char *filename, int lineno)
 {
-	char *s = jsRunScriptResult(t->f0, str, filename, lineno);
-	nzFree(s);
+    nzFree(jsRunScriptResult(t->f0, str, filename, lineno));
 }
 
-char *jsRunScriptWinResult(const char *str,
-const char *filename, 			int lineno)
+char *jsRunScriptWinResult(const char *str, const char *filename, int lineno)
 {
-return jsRunScriptResult(cf, str, filename, lineno);
+    return jsRunScriptResult(cf, str, filename, lineno);
 }
 
 static JSValue create_event(JSContext *cx, JSValueConst parent, const char *evname)


### PR DESCRIPTION
Very initial support for js modules by allowing the module script type and
checking for it both for async and sync cases.

Also some whitespace changes in quickjs integration code.

Appears to work fine in acid3 and jsrt.
