### PR TITLE
Render via tweb using firefox or chrome as a backend

### DIFF
--- a/plugins/config/render-tweb.rc
+++ b/plugins/config/render-tweb.rc
@@ -1,0 +1,77 @@
+# You'll need tweb:
+# https://github.com/bmmcginty/tweb
+# Read the live web through tweb, which drives an ordinary Chrome, Chromium
+# or Firefox and hands the result to edbrowse as html.
+#
+#   b tweb://https://example.com
+#
+# Start the server first, in the tui-browser directory:
+#
+#   npm run edb                 (or: npm run edb -- --browser firefox)
+#
+# Every link and form in the page that comes back points at the server over
+# http, so edbrowse's own machinery — g, i=, i*, ib, rf, ^ — works normally
+# from there on, and the browser keeps your logins and clearance cookies.
+
+plugin {
+    type = */*
+    desc = Read a page through tweb's browser
+    protocol = tweb
+    program = edbrowse-plugin-tweb %i
+    outtype = h
+}
+
+# Send a real click, the kind the browser treats as a person's, to the link
+# on the current line. Audio, fullscreen, the clipboard and popups are gated
+# on that gesture; an ordinary g is a script-initiated click and is not.
+# Adapted from edbrowse's own render-chrome.rc.
+function+twebclick {
+    db0
+    A
+    2,d
+    s;^<br/*><a href='\(.*\)'>$;b $1/click;f
+    bw
+    up
+    db1
+    <*-1
+}
+
+# The accessibility tree, the visible text and the markup, as tweb's reader
+# sees them, for when edbrowse's rendering of a page is not the useful one.
+function+twebax {
+    b ax
+}
+
+function+twebsource {
+    b source
+}
+
+# Shortcuts, so that reaching the web is one short word and an address.
+# ~0 is everything you typed after the function name; the tweb server takes
+# an address the way a url bar does, so no scheme is needed.
+#
+#   <t example.com
+#   <t en.wikipedia.org/wiki/Braille
+#   <t https://skt222.bandcamp.com/album/weird-fish
+#
+# Rename these to whatever your fingers prefer — they are two lines each.
+function+t {
+    b tweb://~0
+}
+
+function+tweb {
+    b tweb://~0
+}
+
+# The tab list, which is also where the address field is when you have not
+# decided where to go yet.
+function+tt {
+    b tweb://tabs
+}
+
+# Search, in the browser, with its cookies and no bot check to fail.
+#
+#   <ts kangaroo habitat
+function+ts {
+    b tweb://https://duckduckgo.com/html/?q=~0
+}

--- a/plugins/scripts/edbrowse-plugin-tweb
+++ b/plugins/scripts/edbrowse-plugin-tweb
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+'use strict';
+
+// The entry point: `b tweb://https://example.com` in edbrowse.
+//
+// It does almost nothing, and that is deliberate. edbrowse forks this script
+// for every fetch of a tweb:// url, so it must not be where the browser
+// lives; it asks the tweb server — which holds the browser session and the
+// element ids — to open the page, and prints what comes back. Every link and
+// form in that page points at the server directly (the document carries a
+// <base href>), so this script is out of the loop from the second page on.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function endpointPath() {
+  const base = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+  return path.join(base, 'tui-browser', 'edb.json');
+}
+
+function page(title, body) {
+  return `<html><head><title>${title}</title></head><body>\n${body}\n</body></html>\n`;
+}
+
+async function main() {
+  const argument = process.argv[2] || '';
+  const wanted = argument.replace(/^tweb:\/\//, '').trim();
+
+  let endpoint = null;
+  try {
+    endpoint = JSON.parse(fs.readFileSync(endpointPath(), 'utf8'));
+  } catch {
+    endpoint = null;
+  }
+  if (!endpoint || !endpoint.port) {
+    process.stdout.write(page('tweb is not running',
+      '<p>tweb is not serving a browser. Start it with:</p>'
+      + '<p>npm run edb</p>'
+      + `<p>in the tui-browser directory, then try again. It writes ${endpointPath()}.</p>`));
+    return;
+  }
+
+  // `b tweb://` with nothing after it, and `b tweb://tabs`, both mean the tab
+  // list: it is the page with the address field on it, so it is the answer to
+  // "I want tweb but I have not decided where yet".
+  //
+  // Everything else is handed on as typed. The server decides what it means —
+  // it is the half that can see whether a host resolves, and it is what the
+  // address field on the page posts to, so there is one answer to
+  // "example.com" rather than two.
+  const base = `http://127.0.0.1:${endpoint.port}/t/${endpoint.token}`;
+  const url = (!wanted || wanted === 'tabs' || wanted === 'tabs/')
+    ? `${base}/tabs`
+    : `${base}/open?url=${encodeURIComponent(wanted)}`;
+
+  try {
+    const response = await fetch(url, { redirect: 'follow' });
+    const text = await response.text();
+    process.stdout.write(text);
+  } catch (err) {
+    process.stdout.write(page('tweb did not answer',
+      `<p>tweb is listening on port ${endpoint.port} according to ${endpointPath()},`
+      + ` but the request failed: ${String(err && err.message || err)}.</p>`
+      + '<p>It may have stopped. Start it again with npm run edb.</p>'));
+  }
+}
+
+main().catch((err) => {
+  process.stdout.write(page('tweb', `<p>${String(err && err.message || err)}</p>`));
+});


### PR DESCRIPTION
Tweb will render full webpages into Edbrowse.
To refresh the view of the page, do rf.
There are multiple page modes, and those modes and the tab list are accessible via line 3.
See https://github.com/bmmcginty/tweb

- **keep line number when doing rf**
- **allow getting and posting form fields via plugin-declared protocols**
- **add support for tweb**
