### PR TITLE
Initialize a in the unreachable pd branch to fix uninitialized-variable warning

### DIFF
--- a/src/jseng-quick.c
+++ b/src/jseng-quick.c
@@ -2624,6 +2624,8 @@ static JSValue nat_fetchHTTP(JSContext * cx, JSValueConst this, int argc, JSValu
 	    } else if(pd == 1) {
         	createFormattedString(&a, "%s\1`b64+%s",
 	        incoming_url, incoming_payload);
+	    } else {
+		a = cloneString(incoming_url);
 	    }
 	} else {
 	a = cloneString(incoming_url);


### PR DESCRIPTION
I always build edbrowse with zig cc, and this one surfaced after recent changes.
